### PR TITLE
build: fix comparison logic for linaro variant < 8

### DIFF
--- a/build
+++ b/build
@@ -390,7 +390,7 @@ function download_sources() {
 
         if [[ ! -d gcc-${REPO} ]]; then
             header "DOWNLOADING GCC"
-            if [[ ${SOURCE} == "linaro" && ${VERSION} -le 8 ]]; then
+            if [[ ${SOURCE} == "linaro" && ${VERSION} -ge 8 ]]; then
                 # Fetch the so-called ARM toolchain from svn
                 svn co svn://gcc.gnu.org/svn/gcc/branches/${GCC} gcc-${REPO}
             else


### PR DESCRIPTION
* The derp was introduced in commit e48970f2a8f479fe427a6bc9a5dc3d34e0fcdcb1 .